### PR TITLE
chore: shorter package name without slash

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -111,7 +111,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/${{ github.repository }}/quantel-gateway
+            ghcr.io/${{ github.repository }}
           tags: |
             type=schedule
             type=ref,event=branch


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Shorten the name of the package (and removing a slash from the name)


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
